### PR TITLE
LR1121 power correction mechanism

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -1,3 +1,6 @@
+#ifndef _HARDWARE_H_
+#define _HARDWARE_H_
+
 #include <stdint.h>
 
 typedef enum {
@@ -44,6 +47,7 @@ typedef enum {
     HARDWARE_power_high,
     HARDWARE_power_max,
     HARDWARE_power_default,
+    HARDWARE_apply_power_correction,
 
     HARDWARE_power_pdet,
     HARDWARE_power_pdet_intercept,
@@ -147,6 +151,10 @@ typedef enum {
     HARDWARE_vtx_amp_pwm_25mW,
     HARDWARE_vtx_amp_pwm_100mW,
 
+    // Frequency-power correction coefficients
+    HARDWARE_freq_power_table,
+    HARDWARE_freq_power_table_count,
+
     HARDWARE_LAST
 } nameType;
 
@@ -157,3 +165,5 @@ const int hardware_int(nameType name);
 const float hardware_float(nameType name);
 const int16_t* hardware_i16_array(nameType name);
 const uint16_t* hardware_u16_array(nameType name);
+
+#endif /* _HARDWARE_H_ */

--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -78,6 +78,7 @@
 #define HighPower (PowerLevels_e)hardware_int(HARDWARE_power_high)
 #define MaxPower (PowerLevels_e)hardware_int(HARDWARE_power_max)
 #define DefaultPower (PowerLevels_e)hardware_int(HARDWARE_power_default)
+#define OPT_APPLY_POWER_CORRECTION hardware_flag(HARDWARE_apply_power_correction)
 
 #define USE_SKY85321
 #define GPIO_PIN_PA_PDET hardware_pin(HARDWARE_power_pdet)

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -2,7 +2,9 @@
 #include "LR1121_hal.h"
 #include "LR1121.h"
 #include "logging.h"
+#include "options.h"
 #include <math.h>
+#include "ArduinoJson.h"
 
 LR1121Hal hal;
 LR1121Driver *LR1121Driver::instance = NULL;
@@ -35,6 +37,124 @@ static uint32_t endTX;
 #else
   #define OPT_USE_SX1276_RFO_HF false
 #endif
+
+void LR1121Driver::TestOutputPowerAtFreq(uint32_t freq_hz, int8_t power_dbm)
+{
+    SetFrequencyHz(freq_hz, SX12XX_Radio_1);
+
+    // Set output power (true = subGHz)
+    SetOutputPower(power_dbm, true);
+    // Start continuous wave (CW) output
+    startCWTest(freq_hz, SX12XX_Radio_1);
+
+    DBGLN("CW output at %d MHz, power %d dBm for 5 seconds", freq_hz/1000000, power_dbm);
+    uint32_t start = millis();
+    while (millis() - start < 5000) {
+        delay(100);
+    }
+
+    // Stop transmission (put radio to standby/sleep)
+    SetMode(LR1121_MODE_STDBY_RC, SX12XX_Radio_1);
+    DBGLN("CW output stopped");
+}
+
+typedef struct {
+    uint16_t freqMHz;
+    int8_t powerCorrectionDbm;
+} FreqPowerEntry;
+
+static FreqPowerEntry* freqPowerTable = nullptr;
+static int freqPowerTableSize = 0;
+
+bool LR1121Driver::LoadFreqPowerTable(const char* jsonConfig)
+{
+    DynamicJsonDocument doc(4096);
+    DeserializationError error = deserializeJson(doc, jsonConfig);
+    
+    if (error) {
+        DBGLN("Failed to parse JSON config: %s", error.c_str());
+        return false;
+    }
+
+    if (!doc.containsKey("freq_power_table")) {
+        DBGLN("No freq_power_table found in JSON config");
+        return false;
+    }
+
+    JsonArray table = doc["freq_power_table"];
+    freqPowerTableSize = table.size();
+    
+    if (freqPowerTable != nullptr) {
+        delete[] freqPowerTable;
+    }
+    
+    freqPowerTable = new FreqPowerEntry[freqPowerTableSize];
+    
+    DBGLN("Loading frequency-power table with %d entries:", freqPowerTableSize);
+    for (int i = 0; i < freqPowerTableSize; i++) {
+        JsonArray entry = table[i];
+        freqPowerTable[i].freqMHz = entry[0];
+        freqPowerTable[i].powerCorrectionDbm = entry[1];
+    }
+    
+    return true;
+}
+
+void LR1121Driver::CleanupFreqPowerTable()
+{
+    if (freqPowerTable != nullptr) {
+        delete[] freqPowerTable;
+        freqPowerTable = nullptr;
+        freqPowerTableSize = 0;
+    }
+}
+
+#define POWER_VALUE_LIMIT_DBM 20
+
+int8_t LR1121Driver::ApplyPowerFrequencyCorrection(int8_t requestedPowerDbm, uint32_t freqHz)
+{
+    if (freqPowerTable == nullptr || freqPowerTableSize == 0) {
+        DBGLN("Failed to load power correction table");
+        return requestedPowerDbm;
+    }
+
+    const uint16_t freqMHz = freqHz / 1000000;
+    int8_t correctionDb = 0;
+
+    if (freqMHz <= freqPowerTable[0].freqMHz)
+        correctionDb = freqPowerTable[0].powerCorrectionDbm;
+    else if (freqMHz >= freqPowerTable[freqPowerTableSize - 1].freqMHz)
+        correctionDb = freqPowerTable[freqPowerTableSize - 1].powerCorrectionDbm;
+    else {
+        for (int i = 0; i < freqPowerTableSize - 1; ++i) {
+            if (freqMHz >= freqPowerTable[i].freqMHz && freqMHz <= freqPowerTable[i + 1].freqMHz) {
+                int16_t f1 = freqPowerTable[i].freqMHz;
+                int16_t f2 = freqPowerTable[i + 1].freqMHz;
+                int16_t p1 = freqPowerTable[i].powerCorrectionDbm;
+                int16_t p2 = freqPowerTable[i + 1].powerCorrectionDbm;
+                
+                // (freqMHz - f1) * (p2 - p1) / (f2 - f1) + p1
+                int16_t freqDiff = freqMHz - f1;
+                int16_t powerDiff = p2 - p1;
+                int16_t freqRange = f2 - f1;
+                
+                int32_t interpolated = ((int32_t)freqDiff * powerDiff) / freqRange + p1;
+                correctionDb = (int8_t)interpolated;
+                break;
+            }
+        }
+    }
+
+    int8_t correctedPowerDbm = requestedPowerDbm + correctionDb;
+
+    // Constrain power to max 20 dBm
+    if (correctedPowerDbm > POWER_VALUE_LIMIT_DBM) correctedPowerDbm = POWER_VALUE_LIMIT_DBM;
+
+    DBGLN("Freq: %u MHz | Base: %d dBm | Correction: %d dBm | Applied : %d dBm",
+           freqMHz, requestedPowerDbm, correctionDb, correctedPowerDbm);
+
+    return correctedPowerDbm;
+}
 
 LR1121Driver::LR1121Driver(): SX12xxDriverCommon()
 {
@@ -144,6 +264,14 @@ transitioning from FS mode and the other from Standby mode. This causes the tx d
         rssiCalbuf[9] = 0;
         rssiCalbuf[10] = 0;
         hal.WriteCommand(LR11XX_RADIO_SET_RSSI_CALIBRATION_OC, rssiCalbuf, sizeof(rssiCalbuf), SX12XX_Radio_All);
+    }
+
+    // Load frequency-power table from hardware configuration
+    if (OPT_APPLY_POWER_CORRECTION) {
+        const char* hardwareConfig = getHardware().c_str();
+        if (!LoadFreqPowerTable(hardwareConfig)) {
+            DBGLN("Failed to load frequency-power table from hardware configuration");
+        }
     }
 
     return true;
@@ -354,6 +482,8 @@ void LR1121Driver::SetOutputPower(int8_t power, bool isSubGHz)
         }
         else
         {
+            if (OPT_APPLY_POWER_CORRECTION)
+                power = ApplyPowerFrequencyCorrection(power, currFreq);            
             pwrNew = constrain(power, LR1121_POWER_MIN_HP_PA, LR1121_POWER_MAX_HP_PA);
         }
 

--- a/src/lib/LR1121Driver/LR1121.h
+++ b/src/lib/LR1121Driver/LR1121.h
@@ -89,4 +89,9 @@ private:
     void TXnbISR(); // ISR for non-blocking TX routine
     void CommitOutputPower();
     void WriteOutputPower(uint8_t pwr, bool isSubGHz, SX12XX_Radio_Number_t radioNumber);
+
+    void TestOutputPowerAtFreq(uint32_t freq_hz, int8_t power_dbm);
+    bool LoadFreqPowerTable(const char* jsonConfig);
+    void CleanupFreqPowerTable();
+    int8_t ApplyPowerFrequencyCorrection(int8_t userPowerDbm, uint32_t freqHz);
 };

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -59,6 +59,7 @@ static const struct {
     {HARDWARE_power_high, "power_high", INT},
     {HARDWARE_power_max, "power_max", INT},
     {HARDWARE_power_default, "power_default", INT},
+    {HARDWARE_apply_power_correction, "apply_power_correction", BOOL},
     {HARDWARE_power_pdet, "power_pdet", INT},
     {HARDWARE_power_pdet_intercept, "power_pdet_intercept", FLOAT},
     {HARDWARE_power_pdet_slope, "power_pdet_slope", FLOAT},
@@ -138,6 +139,8 @@ static const struct {
     {HARDWARE_vtx_amp_vpd_100mW, "vtx_amp_vpd_100mW", ARRAY},
     {HARDWARE_vtx_amp_pwm_25mW, "vtx_amp_pwm_25mW", ARRAY},
     {HARDWARE_vtx_amp_pwm_100mW, "vtx_amp_pwm_100mW", ARRAY},
+    {HARDWARE_freq_power_table, "freq_power_table", ARRAY},
+    {HARDWARE_freq_power_table_count, "freq_power_table", COUNT},
 };
 
 typedef union {

--- a/src/targets/aeronetix.ini
+++ b/src/targets/aeronetix.ini
@@ -34,6 +34,10 @@ board_config = aeronetix.tx_dual.lr1121_5w_450_750_v1
 extends = env:Unified_ESP32_LR1121_TX_via_UART
 board_config = aeronetix.tx_dual.lr1121_5w_450_750_v1
 
+[env:Aeronetix_ESP32_LR1121_5W_TX_via_UART]
+extends = env:Unified_ESP32_LR1121_TX_via_UART
+board_config = aeronetix.tx_dual.lr1121_5w_v1
+
 [env:Aeronetix_ESP32_LR1121_5W_450_750_TX_via_WIFI]
 extends = env:Unified_ESP32_LR1121_TX_via_WIFI
 board_config = aeronetix.tx_dual.lr1121_5w_450_750_v1


### PR DESCRIPTION
## Add Frequency-Dependent Power Correction for LR1121 (Aeronetix 5W)

### Summary

This PR introduces a frequency-dependent output power correction mechanism for the Aeronetix LR1121 5W target to improve TX's power curve. The driver now applies a correction (in dBm) to the requested output power based on the current transmission frequency, using a table of integer correction values defined in the hardware configuration JSON.

**NOTE: Feature supported across all Aeronetix LR-based targets but currently safely tested only on `Aeronetix_ESP32_LR1121_5W_TX_via_UART` target**

### Key Changes

- **New `freq_power_table` in Hardware JSON:**  
  The hardware configuration now includes a `freq_power_table` array, mapping frequency (MHz) to integer dBm correction values.  
  Example:
  ```json
  "freq_power_table": [
      [150, -3],
      [160, -3],
      ...
      [750, 0]
  ]
  ```

- **Driver Support for Power Correction:**  
  - The LR1121 driver loads the `freq_power_table` at startup.
  - During transmission, the driver applies the appropriate correction (with linear interpolation between table points) to the requested output power.
  - All calculations are performed using integer math, as the hardware only supports integer dBm steps.

- **Debug Output:**  
  - The driver logs the correction process, including the frequency, base power, correction applied, and final power setting.

- **Backward Compatibility:**  
  - If no `freq_power_table` is present, the driver defaults to no correction.
  - If `"apply_power_correction"` set to `false` , correction won't be used as well.
  

- **Improved Output Power Accuracy:**  
  The LR1121’s output power varies with frequency. This mechanism ensures more consistent and accurate output power across the supported frequency range, improving performance and regulatory compliance.

