### PR TITLE
Aeronetix lr1121 RX targets build fix, failing CI jobs fix

### DIFF
--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -79,6 +79,7 @@
 #define HighPower (PowerLevels_e)hardware_int(HARDWARE_power_high)
 #define MaxPower (PowerLevels_e)hardware_int(HARDWARE_power_max)
 #define DefaultPower (PowerLevels_e)hardware_int(HARDWARE_power_default)
+#define OPT_APPLY_POWER_CORRECTION hardware_flag(HARDWARE_apply_power_correction)
 
 #define USE_SKY85321
 #define GPIO_PIN_PA_PDET hardware_pin(HARDWARE_power_pdet)

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -38,6 +38,11 @@ static uint32_t endTX;
   #define OPT_USE_SX1276_RFO_HF false
 #endif
 
+// Refers to Aeronetix frequency dependent amplification correction mechanism for LR1121-based TX targets
+#ifndef OPT_APPLY_POWER_CORRECTION
+    #define OPT_APPLY_POWER_CORRECTION false
+#endif
+
 void LR1121Driver::TestOutputPowerAtFreq(uint32_t freq_hz, int8_t power_dbm)
 {
     SetFrequencyHz(freq_hz, SX12XX_Radio_1);

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -29,6 +29,7 @@ build_flags =
 	-std=c++11
 	-Iinclude
 	-D PROGMEM=""
+	-D UNIT_TEST=1
 	-D TARGET_NATIVE
 	-D CRSF_RX_MODULE
 	-D CRSF_TX_MODULE

--- a/src/targets/common.ini
+++ b/src/targets/common.ini
@@ -58,10 +58,10 @@ build_flags =
 	-I ${PROJECTSRC_DIR}/hal
 build_src_filter = ${common_env_data.build_src_filter} -<ESP8266*.*> -<STM32*.*>
 lib_deps =
-	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
-	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
+	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
 	h2zero/NimBLE-Arduino @ 1.4.1
+	lemmingdev/ESP32-BLE-Gamepad @ 0.5.2
 	bblanchon/ArduinoJson @ 7.0.4
 	${common_env_data.mavlink_lib_dep}
 oled_lib_deps =


### PR DESCRIPTION
Fixed builds of LR1121 based RX targets after power-correction mechanism was introduced for TX configs in #3 .

CI jobs were failing because of PIO update (NimBLE-lib duplicated errors during build), fixed as well.
Refers to: 
- https://github.com/ExpressLRS/ExpressLRS/pull/3224
- https://github.com/ExpressLRS/ExpressLRS/issues/3223
- https://github.com/ExpressLRS/ExpressLRS/issues/3234