### PR TITLE
Aeronetix LR1121 1W 2.4 GHz TX power correction support

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -48,6 +48,7 @@ typedef enum {
     HARDWARE_power_max,
     HARDWARE_power_default,
     HARDWARE_apply_power_correction,
+    HARDWARE_apply_power_correction_dual,
 
     HARDWARE_power_pdet,
     HARDWARE_power_pdet_intercept,
@@ -154,6 +155,8 @@ typedef enum {
     // Frequency-power correction coefficients
     HARDWARE_freq_power_table,
     HARDWARE_freq_power_table_count,
+    HARDWARE_freq_power_table_dual,
+    HARDWARE_freq_power_table_dual_count,
 
     HARDWARE_LAST
 } nameType;

--- a/src/include/target/Unified_ESP32_TX.h
+++ b/src/include/target/Unified_ESP32_TX.h
@@ -79,6 +79,7 @@
 #define MaxPower (PowerLevels_e)hardware_int(HARDWARE_power_max)
 #define DefaultPower (PowerLevels_e)hardware_int(HARDWARE_power_default)
 #define OPT_APPLY_POWER_CORRECTION hardware_flag(HARDWARE_apply_power_correction)
+#define OPT_APPLY_POWER_CORRECTION_DUAL hardware_flag(HARDWARE_apply_power_correction_dual)
 
 #define USE_SKY85321
 #define GPIO_PIN_PA_PDET hardware_pin(HARDWARE_power_pdet)

--- a/src/include/target/Unified_ESP_RX.h
+++ b/src/include/target/Unified_ESP_RX.h
@@ -80,6 +80,7 @@
 #define MaxPower (PowerLevels_e)hardware_int(HARDWARE_power_max)
 #define DefaultPower (PowerLevels_e)hardware_int(HARDWARE_power_default)
 #define OPT_APPLY_POWER_CORRECTION hardware_flag(HARDWARE_apply_power_correction)
+#define OPT_APPLY_POWER_CORRECTION_DUAL hardware_flag(HARDWARE_apply_power_correction_dual)
 
 #define USE_SKY85321
 #define GPIO_PIN_PA_PDET hardware_pin(HARDWARE_power_pdet)

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -81,12 +81,23 @@ bool LR1121Driver::LoadFreqPowerTable(const char* jsonConfig)
         return false;
     }
 
-    if (!doc.containsKey("freq_power_table")) {
-        DBGLN("No freq_power_table found in JSON config");
-        return false;
+    JsonArray table;
+    // SubGHz power correction values 
+    if (OPT_APPLY_POWER_CORRECTION) {
+        if (!doc.containsKey("freq_power_table")) {
+            DBGLN("No freq_power_table found in JSON config");
+            return false;
+        }
+        table = doc["freq_power_table"];
+    } else if (OPT_APPLY_POWER_CORRECTION_DUAL) {
+        // 2.4G power correction values
+        if (!doc.containsKey("freq_power_table_dual")) {
+            DBGLN("No freq_power_table_dual found in JSON config");
+            return false;
+        }
+        table = doc["freq_power_table_dual"];
     }
-
-    JsonArray table = doc["freq_power_table"];
+    
     freqPowerTableSize = table.size();
     
     if (freqPowerTable != nullptr) {
@@ -152,8 +163,9 @@ int8_t LR1121Driver::ApplyPowerFrequencyCorrection(int8_t requestedPowerDbm, uin
 
     int8_t correctedPowerDbm = requestedPowerDbm + correctionDb;
 
-    // Constrain power to max 20 dBm
-    if (correctedPowerDbm > POWER_VALUE_LIMIT_DBM) correctedPowerDbm = POWER_VALUE_LIMIT_DBM;
+    // Constrain power to max 20 dBm for SubGHz PA
+    if (OPT_APPLY_POWER_CORRECTION) 
+        if (correctedPowerDbm > POWER_VALUE_LIMIT_DBM) correctedPowerDbm = POWER_VALUE_LIMIT_DBM;
 
     DBGLN("Freq: %u MHz | Base: %d dBm | Correction: %d dBm | Applied : %d dBm",
            freqMHz, requestedPowerDbm, correctionDb, correctedPowerDbm);
@@ -272,7 +284,7 @@ transitioning from FS mode and the other from Standby mode. This causes the tx d
     }
 
     // Load frequency-power table from hardware configuration
-    if (OPT_APPLY_POWER_CORRECTION) {
+    if (OPT_APPLY_POWER_CORRECTION || OPT_APPLY_POWER_CORRECTION_DUAL) {
         const char* hardwareConfig = getHardware().c_str();
         if (!LoadFreqPowerTable(hardwareConfig)) {
             DBGLN("Failed to load frequency-power table from hardware configuration");
@@ -499,11 +511,15 @@ void LR1121Driver::SetOutputPower(int8_t power, bool isSubGHz)
     }
     else
     {
+        if (OPT_APPLY_POWER_CORRECTION_DUAL) {
+            power = ApplyPowerFrequencyCorrection(power, currFreq);    
+        }
         pwrNew = constrain(power, LR1121_POWER_MIN_HF_PA, LR1121_POWER_MAX_HF_PA);
 
         if ((pwrPendingHF == PWRPENDING_NONE && pwrCurrentHF != pwrNew) || pwrPendingHF != pwrNew)
         {
             pwrPendingHF = pwrNew;
+
         }
     }
 }

--- a/src/lib/LR1121Driver/LR1121.cpp
+++ b/src/lib/LR1121Driver/LR1121.cpp
@@ -42,6 +42,9 @@ static uint32_t endTX;
 #ifndef OPT_APPLY_POWER_CORRECTION
     #define OPT_APPLY_POWER_CORRECTION false
 #endif
+#ifndef OPT_APPLY_POWER_CORRECTION_DUAL
+    #define OPT_APPLY_POWER_CORRECTION_DUAL false
+#endif
 
 void LR1121Driver::TestOutputPowerAtFreq(uint32_t freq_hz, int8_t power_dbm)
 {

--- a/src/lib/OPTIONS/hardware.cpp
+++ b/src/lib/OPTIONS/hardware.cpp
@@ -60,6 +60,7 @@ static const struct {
     {HARDWARE_power_max, "power_max", INT},
     {HARDWARE_power_default, "power_default", INT},
     {HARDWARE_apply_power_correction, "apply_power_correction", BOOL},
+    {HARDWARE_apply_power_correction_dual, "apply_power_correction_dual", BOOL},
     {HARDWARE_power_pdet, "power_pdet", INT},
     {HARDWARE_power_pdet_intercept, "power_pdet_intercept", FLOAT},
     {HARDWARE_power_pdet_slope, "power_pdet_slope", FLOAT},
@@ -141,6 +142,8 @@ static const struct {
     {HARDWARE_vtx_amp_pwm_100mW, "vtx_amp_pwm_100mW", ARRAY},
     {HARDWARE_freq_power_table, "freq_power_table", ARRAY},
     {HARDWARE_freq_power_table_count, "freq_power_table", COUNT},
+    {HARDWARE_freq_power_table_dual, "freq_power_table_dual", ARRAY},
+    {HARDWARE_freq_power_table_dual_count, "freq_power_table_dual", COUNT},
 };
 
 typedef union {

--- a/src/targets/aeronetix.ini
+++ b/src/targets/aeronetix.ini
@@ -38,6 +38,10 @@ board_config = aeronetix.tx_dual.lr1121_5w_450_750_v1
 extends = env:Unified_ESP32_LR1121_TX_via_UART
 board_config = aeronetix.tx_dual.lr1121_5w_v1
 
+[env:Aeronetix_ESP32_LR1121_1W_V3_TX_via_UART]
+extends = env:Unified_ESP32_LR1121_TX_via_UART
+board_config = aeronetix.tx_dual.lr1121_1w_v3
+
 [env:Aeronetix_ESP32_LR1121_5W_450_750_TX_via_WIFI]
 extends = env:Unified_ESP32_LR1121_TX_via_WIFI
 board_config = aeronetix.tx_dual.lr1121_5w_450_750_v1


### PR DESCRIPTION
As the power correction mechanism was introduced in #3  for sub GHz 5W TX, now it's expanded to support high frequency (`dual`) 1W TX in the same manner, but with separate table:
```json
    "apply_power_correction_dual": true,
    "freq_power_table_dual": [
        [1700, -10],
        [1750, -9],
        ...
```
Also other power values applied for HF: `"power_values_dual": [-7,-3,1,4,7,10]`

Tested on new target `Aeronetix_ESP32_LR1121_1W_V3_RX_via_UART` manually.
